### PR TITLE
feat: add crawler test endpoint

### DIFF
--- a/src/main/java/org/koreait/crawler/controllers/CrawlerAdminController.java
+++ b/src/main/java/org/koreait/crawler/controllers/CrawlerAdminController.java
@@ -4,8 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.koreait.crawler.entities.CrawlerConfig;
+import org.koreait.crawler.entities.CrawledData;
 import org.koreait.crawler.services.CrawlerConfigService;
 import org.koreait.crawler.services.CrawlerSettingService;
+import org.koreait.crawler.services.CrawlingService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,11 +17,12 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/crawler")
-@PreAuthorize("hasAuthority('ADMIN)")
+@PreAuthorize("hasAuthority('ADMIN')")
 @Tag(name="크롤러 설정 API", description = "크롤러 설정 및 스케줄러 관리 기능 제공")
 public class CrawlerAdminController {
     private final CrawlerConfigService configService;
     private final CrawlerSettingService settingService;
+    private final CrawlingService crawlingService;
 
     @Operation(summary = "크롤러 사이트 설정 목록")
     @GetMapping("/configs")
@@ -31,6 +34,12 @@ public class CrawlerAdminController {
     @PostMapping("/configs")
     public void save(@RequestBody List<RequestCrawling> forms) {
         configService.save(forms);
+    }
+
+    @Operation(summary = "크롤링 테스트 실행")
+    @PostMapping("/test")
+    public List<CrawledData> test(@RequestBody RequestCrawling form) {
+        return crawlingService.process(form);
     }
 
     @Operation(summary = "스케줄러 상태 조회")

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,11 +1,13 @@
 spring:
-  # 데이터베이스 설정
   datasource:
     driverClassName: org.h2.Driver
     url: jdbc:h2:mem:test
     username: sa
     password:
-
   jpa:
     hibernate:
       ddlAuto: create
+
+api:
+  server:
+    url: http://localhost

--- a/src/test/java/org/koreait/Crawler/controllers/CrawlerAdminControllerTest.java
+++ b/src/test/java/org/koreait/Crawler/controllers/CrawlerAdminControllerTest.java
@@ -1,0 +1,63 @@
+package org.koreait.Crawler.controllers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.koreait.crawler.controllers.RequestCrawling;
+import org.koreait.crawler.entities.CrawledData;
+import org.koreait.crawler.services.CrawlingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"default","test"})
+public class CrawlerAdminControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @MockBean
+    private CrawlingService crawlingService;
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    void testCrawlOnce() throws Exception {
+        CrawledData data = new CrawledData();
+        data.setHash(1);
+        data.setLink("https://example.com");
+        when(crawlingService.process(any(RequestCrawling.class))).thenReturn(List.of(data));
+
+        RequestCrawling form = new RequestCrawling();
+        form.setUrl("https://example.com");
+        String body = om.writeValueAsString(form);
+
+        String response = mockMvc.perform(post("/api/v1/crawler/test")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        List<CrawledData> items = om.readValue(response, new TypeReference<List<CrawledData>>(){});
+        assertEquals(1, items.size());
+        assertEquals("https://example.com", items.get(0).getLink());
+    }
+}

--- a/src/test/java/org/koreait/Crawler/services/CrawlingserviceTest.java
+++ b/src/test/java/org/koreait/Crawler/services/CrawlingserviceTest.java
@@ -2,26 +2,52 @@ package org.koreait.Crawler.services;
 
 import org.junit.jupiter.api.Test;
 import org.koreait.crawler.controllers.RequestCrawling;
+import org.koreait.crawler.entities.CrawledData;
 import org.koreait.crawler.services.CrawlingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.test.context.ActiveProfiles;
 
+import java.net.URI;
 import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
+@ActiveProfiles({"default","test"})
 public class CrawlingserviceTest {
     @Autowired
     private CrawlingService service;
 
+    @MockBean
+    private RestTemplate restTemplate;
+
     @Test
     void crawlingTest() {
+        Map<String, Object> item = Map.of(
+                "link", "https://example.com/1",
+                "date", "2024-01-01",
+                "title", "Title1",
+                "content", "Content1",
+                "is_html", false
+        );
+        ResponseEntity<List> response = ResponseEntity.ok(List.of(item));
+        when(restTemplate.postForEntity(any(URI.class), any(HttpEntity.class), eq(List.class)))
+                .thenReturn(response);
+
         RequestCrawling form = new RequestCrawling();
-        form.setUrl("https://www.me.go.kr/mamo/web/index.do?menuId=631");
-        form.setKeywords(List.of("환경", "수도권"));
-        form.setLinkSelector(".brd_body .title a");
-        form.setTitleSelector(".board_view .board_tit");
-        form.setDateSelector(".board_view .createDate");
-        form.setUrlPrefix("https://www.me.go.kr");
-        service.process(form);
+        form.setUrl("https://example.com");
+
+        List<CrawledData> results = service.process(form);
+        assertEquals(1, results.size());
+        assertEquals("https://example.com/1", results.get(0).getLink());
     }
 }


### PR DESCRIPTION
## Summary
- allow admins to trigger a single crawling test via `/api/v1/crawler/test`
- configure test profile with API URL
- add service and controller tests for crawler functionality

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a6aa1663e08331b4554e03163bf2f1