### PR TITLE
feat: add crawling test endpoint

### DIFF
--- a/src/main/java/org/koreait/crawler/controllers/CrawlerAdminController.java
+++ b/src/main/java/org/koreait/crawler/controllers/CrawlerAdminController.java
@@ -4,8 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.koreait.crawler.entities.CrawlerConfig;
+import org.koreait.crawler.entities.CrawledData;
 import org.koreait.crawler.services.CrawlerConfigService;
 import org.koreait.crawler.services.CrawlerSettingService;
+import org.koreait.crawler.services.CrawlingService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,11 +17,12 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/crawler")
-@PreAuthorize("hasAuthority('ADMIN)")
+@PreAuthorize("hasAuthority('ADMIN')")
 @Tag(name="크롤러 설정 API", description = "크롤러 설정 및 스케줄러 관리 기능 제공")
 public class CrawlerAdminController {
     private final CrawlerConfigService configService;
     private final CrawlerSettingService settingService;
+    private final CrawlingService crawlingService;
 
     @Operation(summary = "크롤러 사이트 설정 목록")
     @GetMapping("/configs")
@@ -31,6 +34,12 @@ public class CrawlerAdminController {
     @PostMapping("/configs")
     public void save(@RequestBody List<RequestCrawling> forms) {
         configService.save(forms);
+    }
+
+    @Operation(summary = "크롤링 테스트")
+    @PostMapping("/test")
+    public List<CrawledData> test(@RequestBody RequestCrawling form) {
+        return crawlingService.process(form);
     }
 
     @Operation(summary = "스케줄러 상태 조회")


### PR DESCRIPTION
## Summary
- add admin endpoint to run a single crawl based on provided configuration and store results
- fix admin controller security annotation

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b20d891883319c0779d2bd812870