### PR TITLE
feat: add social login token endpoint

### DIFF
--- a/src/main/java/org/koreait/member/controllers/MemberController.java
+++ b/src/main/java/org/koreait/member/controllers/MemberController.java
@@ -15,6 +15,7 @@ import org.koreait.member.libs.MemberUtil;
 import org.koreait.member.services.JoinService;
 import org.koreait.member.validators.JoinValidator;
 import org.koreait.member.validators.TokenValidator;
+import org.koreait.member.validators.SocialTokenValidator;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.Errors;
@@ -28,6 +29,7 @@ public class MemberController {
     private final JoinValidator joinValidator;
     private final JoinService joinService;
     private final TokenValidator tokenValidator;
+    private final SocialTokenValidator socialTokenValidator;
     private final TokenService tokenService;
     private final MemberUtil memberUtil;
     private final Utils utils;
@@ -68,6 +70,25 @@ public class MemberController {
         }
 
         return tokenService.create(form.getEmail());
+    }
+
+    /**
+     * 소셜 로그인시 JWT 토큰 발급
+     *
+     * @return
+     */
+    @Operation(summary = "소셜 회원 인증 처리", description = "소셜 채널과 토큰으로 인증한 후 회원 전용 요청을 보낼수 있는 토큰(JWT)을 발급")
+    @ApiResponse(responseCode = "200", description = "인증 성공시 토큰(JWT)발급")
+    @PostMapping("/token/social")
+    public String socialToken(@Valid @RequestBody RequestSocialToken form, Errors errors) {
+
+        socialTokenValidator.validate(form, errors);
+
+        if (errors.hasErrors()) {
+            throw new BadRequestException(utils.getErrorMessages(errors));
+        }
+
+        return tokenService.create(form.getSocialChannel(), form.getSocialToken());
     }
 
 

--- a/src/main/java/org/koreait/member/controllers/RequestSocialToken.java
+++ b/src/main/java/org/koreait/member/controllers/RequestSocialToken.java
@@ -1,0 +1,15 @@
+package org.koreait.member.controllers;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.koreait.member.constants.SocialChannel;
+
+@Data
+public class RequestSocialToken {
+    @NotNull
+    private SocialChannel socialChannel;
+
+    @NotBlank
+    private String socialToken;
+}

--- a/src/main/java/org/koreait/member/validators/SocialTokenValidator.java
+++ b/src/main/java/org/koreait/member/validators/SocialTokenValidator.java
@@ -1,0 +1,33 @@
+package org.koreait.member.validators;
+
+import lombok.RequiredArgsConstructor;
+import org.koreait.member.controllers.RequestSocialToken;
+import org.koreait.member.repositories.MemberRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+@Component
+@RequiredArgsConstructor
+public class SocialTokenValidator implements Validator {
+
+    private final MemberRepository repository;
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return clazz.isAssignableFrom(RequestSocialToken.class);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        if (errors.hasErrors()) {
+            return;
+        }
+
+        RequestSocialToken form = (RequestSocialToken) target;
+        boolean exists = repository.findBySocialChannelAndSocialToken(form.getSocialChannel(), form.getSocialToken()).isPresent();
+        if (!exists) {
+            errors.reject("NotFound.member");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add request and validator for social token
- support JWT issuance via social channel and token

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aa5ebe9c8331bb591f9618a23c15