### PR TITLE
Remove pagination from crawler events list

### DIFF
--- a/src/main/java/org/koreait/crawler/controllers/EventController.java
+++ b/src/main/java/org/koreait/crawler/controllers/EventController.java
@@ -10,8 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.koreait.crawler.entities.CrawledData;
 import org.koreait.crawler.services.CrawledDataInfoService;
 import org.koreait.global.search.CommonSearch;
-import org.koreait.global.search.ListData;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,13 +21,13 @@ public class EventController {
 
     private final CrawledDataInfoService infoService;
 
-    @Operation(summary = "환경 행사 목록 조회", description = "저장된 모든 환경 행사 정보를 페이지 단위로 조회")
+    @Operation(summary = "환경 행사 목록 조회", description = "저장된 모든 환경 행사 정보를 페이징 없이 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "환경 행사 목록"),
             @ApiResponse(responseCode = "204", description = "조회된 데이터 없음")
     })
     @GetMapping
-    public ListData<CrawledData> list(@ModelAttribute CommonSearch search) {
+    public List<CrawledData> list(@ModelAttribute CommonSearch search) {
         return infoService.getList(search);
     }
 

--- a/src/main/java/org/koreait/crawler/services/CrawledDataInfoService.java
+++ b/src/main/java/org/koreait/crawler/services/CrawledDataInfoService.java
@@ -3,39 +3,32 @@ package org.koreait.crawler.services;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.StringExpression;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.koreait.crawler.entities.CrawledData;
 import org.koreait.crawler.entities.QCrawledData;
 import org.koreait.crawler.repositories.CrawledDataRepository;
 import org.koreait.global.exceptions.NotFoundException;
 import org.koreait.global.search.CommonSearch;
-import org.koreait.global.search.ListData;
-import org.koreait.global.search.Pagination;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.StreamSupport;
 
 @Service
 @RequiredArgsConstructor
 public class CrawledDataInfoService {
     private final CrawledDataRepository repository;
-    private final HttpServletRequest request;
 
     /**
-     * 크롤링된 데이터 목록을 페이지 단위로 조회
-     * @param search 공통 검색 및 페이징 정보
-     * @return 목록 데이터와 페이징 정보
+     * 크롤링된 데이터 목록을 조회
+     * @param search 공통 검색 정보
+     * @return 검색 조건에 맞는 모든 데이터
      */
-    public ListData<CrawledData> getList(CommonSearch search) {
-        int page = Math.max(search.getPage(), 1);
-        int limit = 10; // 한 페이지당 10개 고정
-        Pageable pageable = PageRequest.of(page - 1, limit, Sort.by(Sort.Direction.DESC, "date"));
+    public List<CrawledData> getList(CommonSearch search) {
+        Sort sort = Sort.by(Sort.Direction.DESC, "date");
 
         /* 검색 조건 처리 S*/
         String sopt = search.getSopt();
@@ -74,11 +67,8 @@ public class CrawledDataInfoService {
         }
         /* 검색 조건 처리 E*/
 
-        Page<CrawledData> result = repository.findAll(andBuilder, pageable);
-        int total = (int) result.getTotalElements();
-        Pagination pagination = new Pagination(page, total, 10, limit, request);
-
-        return new ListData<>(result.getContent(), pagination);
+        Iterable<CrawledData> result = repository.findAll(andBuilder, sort);
+        return StreamSupport.stream(result.spliterator(), false).toList();
     }
 
     /**

--- a/src/test/java/org/koreait/crawler/controllers/EventControllerTest.java
+++ b/src/test/java/org/koreait/crawler/controllers/EventControllerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.koreait.crawler.entities.CrawledData;
 import org.koreait.crawler.repositories.CrawledDataRepository;
-import org.koreait.global.search.ListData;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,6 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -77,9 +77,9 @@ public class EventControllerTest {
                 .getResponse()
                 .getContentAsString();
 
-        ListData<CrawledData> data = om.readValue(body, new TypeReference<ListData<CrawledData>>() {});
-        assertEquals(2, data.getItems().size());
-        assertEquals(2, data.getItems().get(0).getHash());
+        List<CrawledData> data = om.readValue(body, new TypeReference<List<CrawledData>>() {});
+        assertEquals(2, data.size());
+        assertEquals(2, data.get(0).getHash());
     }
 
     /**
@@ -97,9 +97,9 @@ public class EventControllerTest {
                 .getResponse()
                 .getContentAsString();
 
-        ListData<CrawledData> data = om.readValue(body, new TypeReference<ListData<CrawledData>>() {});
-        assertEquals(1, data.getItems().size());
-        assertEquals("Event1", data.getItems().get(0).getTitle());
+        List<CrawledData> data = om.readValue(body, new TypeReference<List<CrawledData>>() {});
+        assertEquals(1, data.size());
+        assertEquals("Event1", data.get(0).getTitle());
     }
 
     /**


### PR DESCRIPTION
## Summary
- return full event lists without pagination
- adjust crawler data service accordingly
- update tests for unpaginated responses

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.4'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cb8bb3088331bbd7532622096736