### PR TITLE
Normalize crawler links before hashing

### DIFF
--- a/src/main/java/org/koreait/crawler/services/CrawlingService.java
+++ b/src/main/java/org/koreait/crawler/services/CrawlingService.java
@@ -21,9 +21,11 @@ import java.net.URI;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -59,7 +61,7 @@ public class CrawlingService {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
             for (Object data : response.getBody()) {
                 Map<String, Object> item = (Map<String, Object>) data;
-                String link = (String) item.get("link");
+                String link = normalizeLink((String) item.get("link"));
                 int hash = Objects.hash(link);
                 LocalDate date = item.get("date") == null ? null : LocalDate.parse((String) item.get("date"), formatter);
                 String title = (String) item.get("title");
@@ -86,6 +88,31 @@ public class CrawlingService {
         }
 
         return null;
+    }
+
+    /**
+     * jsessionid가 포함된 경우 제거하여 링크를 정규화
+     * @param link 원본 링크
+     * @return 정규화된 링크
+     */
+    private String normalizeLink(String link) {
+        if (link == null) {
+            return null;
+        }
+
+        // 세미콜론으로 연결된 jsessionid 제거
+        link = link.replaceAll("(?i);jsessionid=[^?]*", "");
+
+        int qIndex = link.indexOf('?');
+        if (qIndex != -1) {
+            String base = link.substring(0, qIndex);
+            String query = Arrays.stream(link.substring(qIndex + 1).split("&"))
+                    .filter(p -> !p.toLowerCase().startsWith("jsessionid="))
+                    .collect(Collectors.joining("&"));
+            link = query.isEmpty() ? base : base + "?" + query;
+        }
+
+        return link;
     }
 
     /**


### PR DESCRIPTION
## Summary
- strip `jsessionid` from links prior to hashing
- add utility method to normalize crawler links

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a9568e83b08331b5a702c20ada664f